### PR TITLE
Fix parsing images in parseImage

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -344,7 +344,7 @@ class Parser
 
         $img = $this->dom->createElement('img');
 
-        $img->setAttribute('src', $block->data->url);
+        $img->setAttribute('src', $block->data->file->url);
         $img->setAttribute('alt', $caption);
         
         $figure->appendChild($img);


### PR DESCRIPTION
$block looks like 

object(stdClass)#4365 (5) {                                                                           
  ["file"]=>                                                                                          
  object(stdClass)#5500 (1) {                                                                         
    ["url"]=>                                                                                         
    string(x) "...."             
  }                                                                                                   
  ["caption"]=>                                                                                       
  NULL                                                                                                
  ["withBorder"]=>                                                                                    
  bool(false)                                                                                         
  ["stretched"]=>                                                                                     
  bool(false)                                                                                         
  ["withBackground"]=>                                                                                
  bool(false)                                                                                         
}

img src should be block->data->file->url and not block->data->url

I'm using this library https://github.com/editor-js/image